### PR TITLE
Add Cinder Support for OpenStack Plugin

### DIFF
--- a/src/main/java/com/cloudera/director/openstack/Configurations.java
+++ b/src/main/java/com/cloudera/director/openstack/Configurations.java
@@ -31,4 +31,11 @@ public final class Configurations {
 	 */
 	public static final String CONFIGURATION_FILE_NAME = "openstack-plugin.conf";
 	
+	/**
+	 * The HOCON path prefix for instance flavor id
+	 */
+	
+	public static final String INSTANCE_FLAVOR_ID_SECTION =
+			"openstack.NovaProvider.resourceConfigs.";
 }
+

--- a/src/main/java/com/cloudera/director/openstack/OpenStackCredentials.java
+++ b/src/main/java/com/cloudera/director/openstack/OpenStackCredentials.java
@@ -51,3 +51,4 @@ public class OpenStackCredentials {
 			   credential.equals(cre.getCredential());
 	}
 }
+

--- a/src/main/java/com/cloudera/director/openstack/OpenStackCredentialsProvider.java
+++ b/src/main/java/com/cloudera/director/openstack/OpenStackCredentialsProvider.java
@@ -55,3 +55,4 @@ public class OpenStackCredentialsProvider implements CredentialsProvider<OpenSta
 	}
 
 }
+

--- a/src/main/java/com/cloudera/director/openstack/OpenStackCredentialsProviderConfigurationProperty.java
+++ b/src/main/java/com/cloudera/director/openstack/OpenStackCredentialsProviderConfigurationProperty.java
@@ -26,33 +26,33 @@ import com.cloudera.director.spi.v1.model.util.SimpleConfigurationPropertyBuilde
 public enum OpenStackCredentialsProviderConfigurationProperty implements ConfigurationPropertyToken{
 	
 	KEYSTONE_ENDPOINT(new SimpleConfigurationPropertyBuilder()
-	      .configKey("keystoneEndpoint")
-	      .name("Keystone Endpoint")
-	      .defaultDescription("Endpoint of openstack keystone.")
-	      .defaultErrorMessage("OpenStack credentials configuration is missing the keystone endpoint.")
-	      .required(true)
-	      .build()),
+		  .configKey("keystoneEndpoint")
+		  .name("Keystone Endpoint")
+		  .defaultDescription("Endpoint of openstack keystone.")
+		  .defaultErrorMessage("OpenStack credentials configuration is missing the keystone endpoint.")
+		  .required(true)
+		  .build()),
 	TENANT_NAME(new SimpleConfigurationPropertyBuilder()
-	      .configKey("tenantName")
-	      .name("OpenStack Tenant Name")
-	      .defaultDescription("Tenant Name of openstack.")
-	      .defaultErrorMessage("OpenStack credentials configuration is missing the tenant name.")
-	      .required(true)
-	      .build()),
+		  .configKey("tenantName")
+		  .name("OpenStack Tenant Name")
+		  .defaultDescription("Tenant Name of openstack.")
+		  .defaultErrorMessage("OpenStack credentials configuration is missing the tenant name.")
+		  .required(true)
+		  .build()),
 	USER_NAME(new SimpleConfigurationPropertyBuilder()
-	      .configKey("userName")
-	      .name("OpenStack User Name")
-	      .defaultDescription("Username of openstack.")
-	      .defaultErrorMessage("OpenStack credentials configuration is missing the username.")
-	      .required(true)
-	      .build()),
+		  .configKey("userName")
+		  .name("OpenStack User Name")
+		  .defaultDescription("Username of openstack.")
+		  .defaultErrorMessage("OpenStack credentials configuration is missing the username.")
+		  .required(true)
+		  .build()),
 	PASSWORD(new SimpleConfigurationPropertyBuilder()
-	      .configKey("password")
-	      .name("OpenStack Password")
-	      .defaultDescription("Password of openstack.")
-	      .defaultErrorMessage("OpenStack credentials configuration is missing the password.")
-	      .required(true)
-	      .build());
+		  .configKey("password")
+		  .name("OpenStack Password")
+		  .defaultDescription("Password of openstack.")
+		  .defaultErrorMessage("OpenStack credentials configuration is missing the password.")
+		  .required(true)
+		  .build());
 	
 	/**
 	 * The configuration property.
@@ -75,3 +75,4 @@ public enum OpenStackCredentialsProviderConfigurationProperty implements Configu
 	}
 
 }
+

--- a/src/main/java/com/cloudera/director/openstack/OpenStackLauncher.java
+++ b/src/main/java/com/cloudera/director/openstack/OpenStackLauncher.java
@@ -48,14 +48,14 @@ public class OpenStackLauncher extends AbstractLauncher {
 	public void initialize(File configurationDirectory, HttpProxyParameters httpProxyParameters) {
 		File configFile = new File(configurationDirectory, Configurations.CONFIGURATION_FILE_NAME);
 
-	    if (configFile.canRead()) {	    	
-	    	try{
-	    		config = parseConfigFile(configFile);
-	    		openstackConfig = parseConfigFile(configFile);
-	    	} catch(Exception e) {
-	    		throw new RuntimeException(e);
-	    	}
-	    }
+		if (configFile.canRead()) {
+			try{
+				config = parseConfigFile(configFile);
+				openstackConfig = parseConfigFile(configFile);
+			} catch(Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
 	}
 	
 	/**
@@ -67,7 +67,7 @@ public class OpenStackLauncher extends AbstractLauncher {
 	private static Config parseConfigFile(File configFile) {
 		ConfigParseOptions options = ConfigParseOptions.defaults()
 				.setSyntax(ConfigSyntax.CONF)
-	            .setAllowMissing(false);
+				.setAllowMissing(false);
 
 		return ConfigFactory.parseFileAnySyntax(configFile, options);
 	}
@@ -81,10 +81,11 @@ public class OpenStackLauncher extends AbstractLauncher {
 		
 		LocalizationContext localizationContext = getLocalizationContext(locale);
 
-	    // At this point the configuration object will already contain
-	    // the required data for authentication.	
+		// At this point the configuration object will already contain
+		// the required data for authentication.
 		
 		return  new OpenStackProvider(configuration, openstackConfig, localizationContext);
 	}
 
 }
+

--- a/src/main/java/com/cloudera/director/openstack/OpenStackProvider.java
+++ b/src/main/java/com/cloudera/director/openstack/OpenStackProvider.java
@@ -47,7 +47,7 @@ public class OpenStackProvider extends AbstractCloudProvider {
 	 * The resource provider metadata.
 	 */
 	private static final List<ResourceProviderMetadata> RESOURCE_PROVIDER_METADATA =
-	      Collections.unmodifiableList(Arrays.asList(NovaProvider.METADATA));
+			Collections.unmodifiableList(Arrays.asList(NovaProvider.METADATA));
 	
 	
 	private OpenStackCredentials credentials;
@@ -84,13 +84,13 @@ public class OpenStackProvider extends AbstractCloudProvider {
 
 	@Override
 	protected ConfigurationValidator getResourceProviderConfigurationValidator(
-	      ResourceProviderMetadata resourceProviderMetadata) {
+		  ResourceProviderMetadata resourceProviderMetadata) {
 		ConfigurationValidator providerSpecificValidator;
 		if ( resourceProviderMetadata.getId().equals(NovaProvider.METADATA.getId()) ) {
 			 providerSpecificValidator = new NovaProviderConfigurationValidator(credentials);
 		} else {
-		      throw new IllegalArgumentException("No such provider: " + resourceProviderMetadata.getId());
-	    }
+			  throw new IllegalArgumentException("No such provider: " + resourceProviderMetadata.getId());
+		}
 		
 		return new CompositeConfigurationValidator(METADATA.getProviderConfigurationValidator(),
 				providerSpecificValidator);
@@ -113,3 +113,4 @@ public class OpenStackProvider extends AbstractCloudProvider {
 	}
 
 }
+

--- a/src/main/java/com/cloudera/director/openstack/nova/NovaInstance.java
+++ b/src/main/java/com/cloudera/director/openstack/nova/NovaInstance.java
@@ -210,19 +210,19 @@ public class NovaInstance
 	 * @throws IllegalArgumentException if the instance does not have a valid private IP address
 	 */
 	private static InetAddress getPrivateIpAddress(Server server) {
-	    Preconditions.checkNotNull(server, "instance is null");
-	    InetAddress privateIpAddress = null;
-	    try {
-	    	Iterator<Address> iterator = server.getAddresses().values().iterator();
-	    	Address address = null;
-	    	if (iterator.hasNext()) {
-	    		address = iterator.next();
-	    		privateIpAddress = InetAddress.getByName(address.getAddr());
-	    	}
-	    } catch (UnknownHostException e) {
-	      throw new IllegalArgumentException("Invalid private IP address", e);
-	    }
-	    return privateIpAddress;
+		Preconditions.checkNotNull(server, "instance is null");
+		InetAddress privateIpAddress = null;
+		try {
+			Iterator<Address> iterator = server.getAddresses().values().iterator();
+			Address address = null;
+			if (iterator.hasNext()) {
+				address = iterator.next();
+				privateIpAddress = InetAddress.getByName(address.getAddr());
+			}
+		} catch (UnknownHostException e) {
+		  throw new IllegalArgumentException("Invalid private IP address", e);
+		}
+		return privateIpAddress;
 	}
 
 	/**
@@ -251,3 +251,4 @@ public class NovaInstance
 	}
 
 }
+

--- a/src/main/java/com/cloudera/director/openstack/nova/NovaInstanceState.java
+++ b/src/main/java/com/cloudera/director/openstack/nova/NovaInstanceState.java
@@ -32,7 +32,7 @@ public class NovaInstanceState extends AbstractInstanceState<Status> {
 		INSTANCE_STATE_MAP = Collections.unmodifiableMap(map);
 		
 	}
-	
+
 	/**
 	 * Returns the Director instance state for the specified Nova instance name.
 	 * 
@@ -44,20 +44,20 @@ public class NovaInstanceState extends AbstractInstanceState<Status> {
 				INSTANCE_STATE_MAP.get(Status.UNKNOWN) : INSTANCE_STATE_MAP.get(instanceStateName);
 		
 	}
-    
+
 	/**
 	 * Add an entry in the specified map associating the specified Nova instance state name 
 	 * and a Director instance state with the corresponding instance status.
 	 *  
-	 * @param map                 the map from Nova instance state name to Director instance states
+	 * @param map				 the map from Nova instance state name to Director instance states
 	 * @param instanceStateName   the Nova instance state name
-	 * @param instanceStatus      the corresponding instance status
+	 * @param instanceStatus	  the corresponding instance status
 	 */
 	private static void addInstanceState(Map<Status, NovaInstanceState> map,
 			Status instanceStateName, InstanceStatus instanceStatus) {
 		map.put(instanceStateName, new NovaInstanceState(instanceStatus, instanceStateName));
 	}
-	
+
 	/**
 	 * Create a Nova instance state with the specified parameters.
 	 * 
@@ -70,3 +70,4 @@ public class NovaInstanceState extends AbstractInstanceState<Status> {
 	}
 
 }
+

--- a/src/main/java/com/cloudera/director/openstack/nova/NovaInstanceTemplate.java
+++ b/src/main/java/com/cloudera/director/openstack/nova/NovaInstanceTemplate.java
@@ -61,3 +61,4 @@ public class NovaInstanceTemplate extends ComputeInstanceTemplate{
 	}
 
 }
+

--- a/src/main/java/com/cloudera/director/openstack/nova/NovaInstanceTemplateConfigurationProperty.java
+++ b/src/main/java/com/cloudera/director/openstack/nova/NovaInstanceTemplateConfigurationProperty.java
@@ -22,96 +22,119 @@ import com.cloudera.director.spi.v1.model.util.SimpleConfigurationPropertyBuilde
 
 public enum NovaInstanceTemplateConfigurationProperty implements ConfigurationPropertyToken{
 	 
-	 /**
-	  * The availability zone.
-	  */
-     AVAILABILITY_ZONE(new SimpleConfigurationPropertyBuilder()
-    		 .configKey("availabilityZone")
-    		 .name("Availability zone")
-    		 .widget(ConfigurationProperty.Widget.OPENLIST)
-    		 .defaultDescription("The availability zone")
-    		 .build()),	
-     
-     /**
-      * The image ID.
-      */
-     IMAGE(new SimpleConfigurationPropertyBuilder()
-    		 .configKey(ComputeInstanceTemplateConfigurationPropertyToken.IMAGE.unwrap().getConfigKey())
-    		 .name("Image ID")
-    		 .required(true)
-    		 .widget(ConfigurationProperty.Widget.OPENLIST)
-    		 .defaultDescription("The image id")
-    		 .defaultErrorMessage("Image ID is mandatory")
-    		 .build()),
-     
-     /**
-      * The IDs of the security groups (comma separated).
-      */
-     SECURITY_GROUP_NAMES(new SimpleConfigurationPropertyBuilder()
-    		 .configKey("securityGroupNames")
-    		 .name("Security group names")
-    		 .widget(ConfigurationProperty.Widget.OPENMULTI)
-    		 .required(true)
-    		 .defaultDescription("Specify the list of security group names.")
-    		 .defaultErrorMessage("Security group names are mandatory")
-    		 .build()),
-     
-     /**
-      * The ID of the network.
-      */
-     NETWORK_ID(new SimpleConfigurationPropertyBuilder()
-    		 .configKey("networkId")
-    		 .name("Network ID")
-    		 .required(true)
-    		 .defaultDescription("The network ID")
-    		 .defaultErrorMessage("Network ID is mandatory")
-    		 .build()),
-     
-     /**
-      * The instance type (e.g. m1.medium, m1.large, etc), input must be the name.
-      */
-     TYPE(new SimpleConfigurationPropertyBuilder()
-    		 .configKey(ComputeInstanceTemplateConfigurationPropertyToken.TYPE.unwrap().getConfigKey())
-    		 .name("Instance flavor name")
-    		 .required(true)
-    		 .widget(ConfigurationProperty.Widget.OPENLIST)
-    		 .defaultDescription(
-    			"Size of image to launch.<br />" +
-    			"<a target='_blank' href='http://docs.openstack.org/openstack-ops/content/flavors.html'>More Information</a>")
-    		 .defaultErrorMessage("Instance flavor ID is mandatory")
-    		 .addValidValues(
-    			"m1.tiny",
-    			"m1.small",
-    			"m1.medium",
-    			"m1.large",
-    			"m1.xlarge")
-    		 .build()),
-     
-     /**
-      * Name of the key pair to use for new instances.
-      */
-     KEY_NAME(new SimpleConfigurationPropertyBuilder()
-    		 .configKey("keyName")
-    		 .name("Key name")
-    		 .required(true)
-    		 .widget(ConfigurationProperty.Widget.TEXT)
-    		 .defaultDescription("The name of Nova key pair")
-    		 .build()),
-     
-     /**
-      * Name of the floating IP pool to allocate floating IP for new instances.
-      */
-     FLOATING_IP_POOL(new SimpleConfigurationPropertyBuilder()
-    		 .configKey("floatingIpPoolName")
-    		 .name("FloatingIP pool name")
-    		 .defaultValue(null)
-    		 .widget(ConfigurationProperty.Widget.TEXT)
-    		 .defaultDescription(
-    			"The floating IP pool from which to allocate flaoting IP. "+
-    			"And the default value is null, "+
-    			"we'll not assign floating IP to the instance.")
-    		 .build());
-     
+	/**
+	 * The availability zone.
+	 */
+	AVAILABILITY_ZONE(new SimpleConfigurationPropertyBuilder()
+			.configKey("availabilityZone")
+			.name("Availability zone")
+			.widget(ConfigurationProperty.Widget.OPENLIST)
+			.defaultDescription("The availability zone")
+			.build()),
+	
+	/**
+	 * The image ID.
+	 */
+	IMAGE(new SimpleConfigurationPropertyBuilder()
+			.configKey(ComputeInstanceTemplateConfigurationPropertyToken.IMAGE.unwrap().getConfigKey())
+			.name("Image ID")
+			.required(true)
+			.widget(ConfigurationProperty.Widget.OPENLIST)
+			.defaultDescription("The image id")
+			.defaultErrorMessage("Image ID is mandatory")
+			.build()),
+	
+	/**
+	 * The IDs of the security groups (comma separated).
+	 */
+	SECURITY_GROUP_NAMES(new SimpleConfigurationPropertyBuilder()
+			.configKey("securityGroupNames")
+			.name("Security group names")
+			.widget(ConfigurationProperty.Widget.OPENMULTI)
+			.required(true)
+			.defaultDescription("Specify the list of security group names.")
+			.defaultErrorMessage("Security group names are mandatory")
+			.build()),
+	
+	/**
+	 * The ID of the network.
+	 */
+	NETWORK_ID(new SimpleConfigurationPropertyBuilder()
+			.configKey("networkId")
+			.name("Network ID")
+			.required(true)
+			.defaultDescription("The network ID")
+			.defaultErrorMessage("Network ID is mandatory")
+			.build()),
+	
+	/**
+	 * The instance type (e.g. m1.medium, m1.large, etc), input must be the name.
+	 */
+	TYPE(new SimpleConfigurationPropertyBuilder()
+			.configKey(ComputeInstanceTemplateConfigurationPropertyToken.TYPE.unwrap().getConfigKey())
+			.name("Instance flavor name")
+			.required(true)
+			.widget(ConfigurationProperty.Widget.OPENLIST)
+			.defaultDescription(
+				"Size of image to launch.<br />" +
+				"<a target='_blank' href='http://docs.openstack.org/openstack-ops/content/flavors.html'>More Information</a>")
+			.defaultErrorMessage("Instance flavor ID is mandatory")
+			.addValidValues(
+				"m1.tiny",
+				"m1.small",
+				"m1.medium",
+				"m1.large",
+				"m1.xlarge")
+			.build()),
+	
+	/**
+	 * Name of the key pair to use for new instances.
+	 */
+	KEY_NAME(new SimpleConfigurationPropertyBuilder()
+			.configKey("keyName")
+			.name("Key name")
+			.required(true)
+			.widget(ConfigurationProperty.Widget.TEXT)
+			.defaultDescription("The name of Nova key pair")
+			.build()),
+	
+	/**
+	 * Name of the floating IP pool to allocate floating IP for new instances.
+	 */
+	FLOATING_IP_POOL(new SimpleConfigurationPropertyBuilder()
+			.configKey("floatingIpPoolName")
+			.name("FloatingIP pool name")
+			.defaultValue(null)
+			.widget(ConfigurationProperty.Widget.TEXT)
+			.defaultDescription(
+				"The floating IP pool from which to allocate flaoting IP. "+
+				"And the default value is null, "+
+				"we'll not assign floating IP to the instance.")
+			.build()),
+	
+	/**
+	 * The number of volumes to be attached to each new instance.
+	 */
+	VOLUME_NUMBER(new SimpleConfigurationPropertyBuilder()
+			 .configKey("volumeNumber")
+			.name("Volume number")
+			.required(false)
+			.widget(ConfigurationProperty.Widget.NUMBER)
+			.defaultValue("0")
+			.defaultDescription("The number of volumes attached to each instance. Should be [0..10]")
+			.build()),
+	
+	/**
+	 * The size of volumes to be attached to each new instance.
+	 */
+	VOLUME_SIZE(new SimpleConfigurationPropertyBuilder()
+			.configKey("volumeSize")
+			.name("Volume size")
+			.required(false)
+			.widget(ConfigurationProperty.Widget.NUMBER)
+			.defaultValue("10")
+			.defaultDescription("The size of volumes attached to each instance by GB. Should be 1~200")
+			.build());
 	/**
 	 * The configuration property.
 	 */
@@ -132,3 +155,4 @@ public enum NovaInstanceTemplateConfigurationProperty implements ConfigurationPr
 	}
 	
 }
+

--- a/src/main/java/com/cloudera/director/openstack/nova/NovaInstanceTemplateConfigurationValidator.java
+++ b/src/main/java/com/cloudera/director/openstack/nova/NovaInstanceTemplateConfigurationValidator.java
@@ -20,6 +20,8 @@ import static com.cloudera.director.openstack.nova.NovaInstanceTemplateConfigura
 import static com.cloudera.director.openstack.nova.NovaInstanceTemplateConfigurationProperty.KEY_NAME;
 import static com.cloudera.director.openstack.nova.NovaInstanceTemplateConfigurationProperty.NETWORK_ID;
 import static com.cloudera.director.openstack.nova.NovaInstanceTemplateConfigurationProperty.SECURITY_GROUP_NAMES;
+import static com.cloudera.director.openstack.nova.NovaInstanceTemplateConfigurationProperty.VOLUME_NUMBER;
+import static com.cloudera.director.openstack.nova.NovaInstanceTemplateConfigurationProperty.VOLUME_SIZE;
 import static org.jclouds.openstack.nova.v2_0.domain.Image.Status.ACTIVE;
 import static com.cloudera.director.spi.v1.model.InstanceTemplate.InstanceTemplateConfigurationPropertyToken.INSTANCE_NAME_PREFIX;
 import static com.cloudera.director.spi.v1.model.util.Validations.addError;
@@ -46,196 +48,253 @@ import com.google.common.base.Throwables;
  * Validates Nova instance template configuration.
  */
 public class NovaInstanceTemplateConfigurationValidator implements ConfigurationValidator{
-    private static final Logger LOG = 
-    		LoggerFactory.getLogger(NovaInstanceTemplateConfigurationValidator.class);
-    
-    @VisibleForTesting
-    static final String INVALID_AVAILABILITY_ZONE_MSG = "Invalid availability zone: %s";
-    
-    @VisibleForTesting
-    static final String INVALID_IMAGE_ID = "Invalid image id: %s";
-    
-    @VisibleForTesting
-    static final String PREFIX_MISSING_MSG = "Instance name prefix must be provided.";
-    
-    @VisibleForTesting
-    static final String INVALID_PREFIX_LENGTH_MSG = "Instance name prefix must between 1 and 26 characters.";
-    
-    @VisibleForTesting
-    static final String INVALID_KEY_NAME_MSG = "Invalid key name: %s";
-    
-    @VisibleForTesting
-    static final String INVALID_SECURITY_GROUP_NAME_MSG = "Invalid security group names";
-    
-    /**
-     * The Nova provider
-     */
-    private final NovaProvider provider;
-    
-    /**
-     * Create a Nova instance template configuration validator with the specified parameters.
-     * 
-     * @param provider the Nova provider
-     */
-    public NovaInstanceTemplateConfigurationValidator(NovaProvider provider) {
-    	this.provider = Preconditions.checkNotNull(provider,"provider");
-    }
-    
-    @Override
-    public void validate(String name, Configured configuration,
-    		PluginExceptionConditionAccumulator accumulator, LocalizationContext localizationContext) {
-	     
-    	NovaApi novaApi = provider.getNovaApi();
-    	String region = provider.getRegion();
-    	
-    	checkAvailabilityZone(novaApi, region,configuration, accumulator, localizationContext);
-    	checkImage(novaApi, region,configuration, accumulator, localizationContext);
-    	checkKeyName(novaApi, region, configuration, accumulator, localizationContext);
-    	checkSecurityGroupNames(novaApi, region, configuration, accumulator, localizationContext);
-    	checkPrefix(configuration, accumulator, localizationContext);
-    }
-    
-    /**
-     * Validate the configured availability zone.
-     * 
-     * @param novaApi  the novaApi
-     * @param region   the region
-     * @param configuration the configuration to be validated
-     * @param accumulator   the exception condition accumulator
-     * @param localizationContext	the localization context
-     */
-    @VisibleForTesting
-    void checkAvailabilityZone(NovaApi novaApi,
-    		String region,
-    		Configured configuration,
-    		PluginExceptionConditionAccumulator accumulator,
-    		LocalizationContext localizationContext) {
-    	String zoneName = configuration.getConfigurationValue(AVAILABILITY_ZONE, localizationContext);
-    	if(zoneName != null) {
-    		LOG.info(">> Describing zone '{}",zoneName);
-    		
-    		try {
-    			if (!novaApi.getAvailabilityZoneApi(region).get().listAvailabilityZones().contains(zoneName)){
-    				addError(accumulator, AVAILABILITY_ZONE, localizationContext, null, INVALID_AVAILABILITY_ZONE_MSG, zoneName);
-    			}
-    		}
-    		catch (Exception e) {
-    			throw Throwables.propagate(e);
-    		}
-    	} 	
-    }
+	private static final Logger LOG =
+			LoggerFactory.getLogger(NovaInstanceTemplateConfigurationValidator.class);
 
-    /**
-     * Validates the configured Image.
-     * 
-     * @param novaApi	the novaApi 
-     * @param region	the region
-     * @param configuration	the configuration to be validated
-     * @param accumulator	the exception condition accumulator
-     * @param localizationContext	the localization context
-     */
-    @VisibleForTesting
-    void checkImage(NovaApi novaApi,
-    		String region,
-    		Configured configuration,
-    		PluginExceptionConditionAccumulator accumulator,
-    		LocalizationContext localizationContext) {
-    	String imageID = configuration.getConfigurationValue(IMAGE, localizationContext);
+	@VisibleForTesting
+	static final String INVALID_AVAILABILITY_ZONE_MSG = "Invalid availability zone: %s";
+
+	@VisibleForTesting
+	static final String INVALID_IMAGE_ID = "Invalid image id: %s";
+
+	@VisibleForTesting
+	static final String PREFIX_MISSING_MSG = "Instance name prefix must be provided.";
+
+	@VisibleForTesting
+	static final String INVALID_PREFIX_LENGTH_MSG = "Instance name prefix must between 1 and 26 characters.";
+
+	@VisibleForTesting
+	static final String INVALID_KEY_NAME_MSG = "Invalid key name: %s";
+
+	@VisibleForTesting
+	static final String INVALID_SECURITY_GROUP_NAME_MSG = "Invalid security group names";
+
+	@VisibleForTesting
+	static final String INVALID_VOLUME_NUMBER_MSG = "Invalid volume number";
+
+	@VisibleForTesting
+	static final String INVALID_VOLUME_SIZE_MSG = "Invalid volume size";
+
+	/**
+	 * The Nova provider
+	 */
+	private final NovaProvider provider;
+
+	/**
+	 * Create a Nova instance template configuration validator with the specified parameters.
+	 * @param provider the Nova provider
+	 */
+	public NovaInstanceTemplateConfigurationValidator(NovaProvider provider) {
+		this.provider = Preconditions.checkNotNull(provider,"provider");
+	}
+
+	@Override
+	public void validate(String name, Configured configuration,
+			PluginExceptionConditionAccumulator accumulator, LocalizationContext localizationContext) {
 		
-    	LOG.info(">> Querying IMAGE '{}'", imageID);
-    	try {
-    		  ImageApi imageApi = novaApi.getImageApi(region);
-    		  if (imageApi.get(imageID).getStatus() != ACTIVE) {
-					addError(accumulator, IMAGE, localizationContext, null, INVALID_IMAGE_ID, imageID);
-    		  }
-    	}
-    	catch (Exception e) {
-    		throw Throwables.propagate(e);
-    	}
-    }
-    
-    /**
-     * Validates the Nova key pair.
-     * 
-     * @param novaApi	the novaApi 
-     * @param region	the region
-     * @param configuration	the configuration to be validated
-     * @param accumulator	the exception condition accumulator
-     * @param localizationContext	the localization context
-     */
-    @VisibleForTesting
-    void checkKeyName(NovaApi novaApi,
-    		String region,
-    		Configured configuration,
-    		PluginExceptionConditionAccumulator accumulator,
-    		LocalizationContext localizationContext) {
-    	String keyName = configuration.getConfigurationValue(KEY_NAME, localizationContext);
-    	LOG.info(">> Query key pair");
-    	try {
-    			KeyPairApi keyPairApi = novaApi.getKeyPairApi(region).get();
-    			if (!keyPairApi.list().contains(keyName)) {
-    				addError(accumulator, KEY_NAME, localizationContext, null, INVALID_KEY_NAME_MSG, keyName);
-    			}
-    	}
-    	catch (Exception e) {
-    		throw Throwables.propagate(e);
-    	}	
-    }
-   
-    /**
-     * Validates the configured security group names.
-     * 
-     * @param novaApi	the novaApi 
-     * @param region	the region
-     * @param configuration	the configuration to be validated
-     * @param accumulator	the exception condition accumulator
-     * @param localizationContext	the localization context
-     */
-    @VisibleForTesting
-    void checkSecurityGroupNames(NovaApi novaApi,
-    		String region,
-    		Configured configuration,
-    		PluginExceptionConditionAccumulator accumulator,
-    		LocalizationContext localizationContext) {	
-        List<String> securityGroupsNames = NovaInstanceTemplate.CSV_SPLITTER.splitToList(
-                configuration.getConfigurationValue(SECURITY_GROUP_NAMES, localizationContext));
-    	
-        for (String securityGroupName : securityGroupsNames) {
-        	LOG.info(">> Query security group Name '{}'", securityGroupName);
-        	
-        	try {
-        		SecurityGroupApi secgroupApi = novaApi.getSecurityGroupApi(region).get();
-    			if (!secgroupApi.list().contains(securityGroupName)) {
-    				addError(accumulator, SECURITY_GROUP_NAMES, localizationContext, null, INVALID_SECURITY_GROUP_NAME_MSG, securityGroupName);
-    			}
-        	}
-        	catch (Exception e) {
-        		throw Throwables.propagate(e);
-        	}
-        }	
-    }
-    
-    /**
-     * Validates the configured prefix.
-     * 
-     * @param configuration		the configuration to be validated
-     * @param accumulator		the exception condition accumulator
-     * @param localizationContext	the localization context
-     */
-    static void checkPrefix(Configured configuration,
-    		PluginExceptionConditionAccumulator accumulator,
-    		LocalizationContext localizationContext) {
-    	String instanceNamePrefix = configuration.getConfigurationValue(INSTANCE_NAME_PREFIX, localizationContext);
-    	LOG.info(">> Validating prefix '{}'", instanceNamePrefix);
-    	if (instanceNamePrefix == null) {
-    		addError(accumulator, INSTANCE_NAME_PREFIX, localizationContext, null, PREFIX_MISSING_MSG);		
-    	}
-    	else {
-    		int length = instanceNamePrefix.length();
-    		if (length > 218) {
-    			addError(accumulator, INSTANCE_NAME_PREFIX, localizationContext, null , INVALID_PREFIX_LENGTH_MSG);
-    		}
-    	}
-    }
+		NovaApi novaApi = provider.getNovaApi();
+		String region = provider.getRegion();
+		
+		checkAvailabilityZone(novaApi, region,configuration, accumulator, localizationContext);
+		checkImage(novaApi, region,configuration, accumulator, localizationContext);
+		checkKeyName(novaApi, region, configuration, accumulator, localizationContext);
+		checkSecurityGroupNames(novaApi, region, configuration, accumulator, localizationContext);
+		checkPrefix(configuration, accumulator, localizationContext);
+	}
+
+	/**
+	 * Validate the configured availability zone.
+	 * @param novaApi  the novaApi
+	 * @param region   the region
+	 * @param configuration the configuration to be validated
+	 * @param accumulator   the exception condition accumulator
+	 * @param localizationContext	the localization context
+	 */
+	@VisibleForTesting
+	void checkAvailabilityZone(NovaApi novaApi,
+			String region,
+			Configured configuration,
+			PluginExceptionConditionAccumulator accumulator,
+			LocalizationContext localizationContext) {
+		String zoneName = configuration.getConfigurationValue(AVAILABILITY_ZONE, localizationContext);
+		if(zoneName != null) {
+			LOG.info(">> Describing zone '{}",zoneName);
+			
+			try {
+				if (!novaApi.getAvailabilityZoneApi(region).get().listAvailabilityZones().contains(zoneName)){
+					addError(accumulator, AVAILABILITY_ZONE, localizationContext, null, INVALID_AVAILABILITY_ZONE_MSG, zoneName);
+				}
+			}
+			catch (Exception e) {
+				throw Throwables.propagate(e);
+			}
+		}
+	}
+
+	/**
+	 * Validates the configured Image.
+	 *
+	 * @param novaApi	the novaApi
+	 * @param region	the region
+	 * @param configuration	the configuration to be validated
+	 * @param accumulator	the exception condition accumulator
+	 * @param localizationContext	the localization context
+	 */
+	@VisibleForTesting
+	void checkImage(NovaApi novaApi,
+			String region,
+			Configured configuration,
+			PluginExceptionConditionAccumulator accumulator,
+			LocalizationContext localizationContext) {
+		String imageID = configuration.getConfigurationValue(IMAGE, localizationContext);
+		
+		LOG.info(">> Querying IMAGE '{}'", imageID);
+		try {
+			ImageApi imageApi = novaApi.getImageApi(region);
+			if (imageApi.get(imageID).getStatus() != ACTIVE) {
+				addError(accumulator, IMAGE, localizationContext, null, INVALID_IMAGE_ID, imageID);
+			}
+		}
+		catch (Exception e) {
+			throw Throwables.propagate(e);
+		}
+	}
+
+	/**
+	 * Validates the Nova key pair.
+	 * @param novaApi	the novaApi
+	 * @param region	the region
+	 * @param configuration	the configuration to be validated
+	 * @param accumulator	the exception condition accumulator
+	 * @param localizationContext	the localization context
+	 */
+	@VisibleForTesting
+	void checkKeyName(NovaApi novaApi,
+			String region,
+			Configured configuration,
+			PluginExceptionConditionAccumulator accumulator,
+			LocalizationContext localizationContext) {
+		String keyName = configuration.getConfigurationValue(KEY_NAME, localizationContext);
+		LOG.info(">> Query key pair");
+		try {
+			KeyPairApi keyPairApi = novaApi.getKeyPairApi(region).get();
+			if (!keyPairApi.list().contains(keyName)) {
+				addError(accumulator, KEY_NAME, localizationContext, null, INVALID_KEY_NAME_MSG, keyName);
+			}
+		}
+		catch (Exception e) {
+			throw Throwables.propagate(e);
+		}
+	}
+
+	/**
+	 * Validates the configured security group names.
+	 * @param novaApi	the novaApi
+	 * @param region	the region
+	 * @param configuration	the configuration to be validated
+	 * @param accumulator	the exception condition accumulator
+	 * @param localizationContext	the localization context
+	 */
+	@VisibleForTesting
+	void checkSecurityGroupNames(NovaApi novaApi,
+			String region,
+			Configured configuration,
+			PluginExceptionConditionAccumulator accumulator,
+			LocalizationContext localizationContext) {
+		List<String> securityGroupsNames = NovaInstanceTemplate.CSV_SPLITTER.splitToList(
+				configuration.getConfigurationValue(SECURITY_GROUP_NAMES, localizationContext));
+		
+		for (String securityGroupName : securityGroupsNames) {
+			LOG.info(">> Query security group Name '{}'", securityGroupName);
+			
+			try {
+				SecurityGroupApi secgroupApi = novaApi.getSecurityGroupApi(region).get();
+				if (!secgroupApi.list().contains(securityGroupName)) {
+					addError(accumulator, SECURITY_GROUP_NAMES, localizationContext, null, INVALID_SECURITY_GROUP_NAME_MSG, securityGroupName);
+				}
+			}
+			catch (Exception e) {
+				throw Throwables.propagate(e);
+			}
+		}
+	}
+
+	/**
+	 * Validates the configured prefix.
+	 *
+	 * @param configuration		the configuration to be validated
+	 * @param accumulator		the exception condition accumulator
+	 * @param localizationContext	the localization context
+	 */
+	static void checkPrefix(Configured configuration,
+			PluginExceptionConditionAccumulator accumulator,
+			LocalizationContext localizationContext) {
+		String instanceNamePrefix = configuration.getConfigurationValue(INSTANCE_NAME_PREFIX, localizationContext);
+		LOG.info(">> Validating prefix '{}'", instanceNamePrefix);
+		if (instanceNamePrefix == null) {
+			addError(accumulator, INSTANCE_NAME_PREFIX, localizationContext, null, PREFIX_MISSING_MSG);
+		}
+		else {
+			int length = instanceNamePrefix.length();
+			if (length > 218) {
+				addError(accumulator, INSTANCE_NAME_PREFIX, localizationContext, null , INVALID_PREFIX_LENGTH_MSG);
+			}
+		}
+	}
+
+	/**
+	 * Validates the configured volume number.
+	 * @param configuration		the configuration to be validated.
+	 * @param accumulator		the exception condition accumulator.
+	 * @param localizationContext		the localization context.
+	 */
+	static void checkVolumeNum(Configured configuration,
+			PluginExceptionConditionAccumulator accumulator,
+			LocalizationContext localizationContext) {
+		String volNum = configuration.getConfigurationValue(VOLUME_NUMBER, localizationContext);
+		LOG.info(">> Validating volume number '{}'", volNum);
+		if (volNum == null){
+			addError(accumulator, VOLUME_NUMBER, localizationContext, null , INVALID_VOLUME_NUMBER_MSG);
+		}
+		else {
+			try {
+				int volnum = Integer.parseInt(volNum);
+				if (volnum < 0) {
+					addError(accumulator, VOLUME_NUMBER, localizationContext, null , INVALID_VOLUME_NUMBER_MSG);
+				}
+			}
+			catch (Exception e) {
+				addError(accumulator, VOLUME_NUMBER, localizationContext, null , INVALID_VOLUME_NUMBER_MSG);
+			}
+		}
+	}
+
+	/**
+	 * Validates the configured volume size.
+	 * @param configuration		the configuration to be validated.
+	 * @param accumulator		the exception condition accumulator.
+	 * @param localizationContext		the localization context.
+	 */
+	static void checkVolumeSize(Configured configuration,
+			PluginExceptionConditionAccumulator accumulator,
+			LocalizationContext localizationContext) {
+		String volSize= configuration.getConfigurationValue(VOLUME_SIZE, localizationContext);
+		LOG.info(">> Validating volume size '{}'", volSize);
+		if (volSize == null){
+			addError(accumulator, VOLUME_SIZE, localizationContext, null , INVALID_VOLUME_SIZE_MSG);
+		}
+		else {
+			try {
+				int volsize = Integer.parseInt(volSize);
+				if (volsize < 1) {
+					addError(accumulator, VOLUME_SIZE, localizationContext, null , INVALID_VOLUME_SIZE_MSG);
+				}
+			}
+			catch (Exception e) {
+				addError(accumulator, VOLUME_SIZE, localizationContext, null , INVALID_VOLUME_SIZE_MSG);
+			}
+		}
+	}
 
 }
+

--- a/src/main/java/com/cloudera/director/openstack/nova/NovaProvider.java
+++ b/src/main/java/com/cloudera/director/openstack/nova/NovaProvider.java
@@ -15,6 +15,7 @@
  */
 package com.cloudera.director.openstack.nova;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -26,17 +27,28 @@ import java.util.concurrent.TimeUnit;
 import org.jclouds.ContextBuilder;
 import org.jclouds.apis.ApiMetadata;
 import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
+import org.jclouds.openstack.cinder.v1.CinderApi;
+import org.jclouds.openstack.cinder.v1.CinderApiMetadata;
+import org.jclouds.openstack.cinder.v1.domain.Volume;
+import org.jclouds.openstack.cinder.v1.features.VolumeApi;
+import org.jclouds.openstack.cinder.v1.options.CreateVolumeOptions;
+import org.jclouds.openstack.cinder.v1.predicates.VolumePredicates;
 import org.jclouds.openstack.nova.v2_0.NovaApi;
 import org.jclouds.openstack.nova.v2_0.NovaApiMetadata;
 import org.jclouds.openstack.nova.v2_0.domain.Address;
 import org.jclouds.openstack.nova.v2_0.domain.FloatingIP;
+import org.jclouds.openstack.nova.v2_0.domain.FloatingIPPool;
 import org.jclouds.openstack.nova.v2_0.domain.Server;
 import org.jclouds.openstack.nova.v2_0.domain.Server.Status;
 import org.jclouds.openstack.nova.v2_0.domain.ServerCreated;
+import org.jclouds.openstack.nova.v2_0.domain.VolumeAttachment;
 import org.jclouds.openstack.nova.v2_0.extensions.FloatingIPApi;
+import org.jclouds.openstack.nova.v2_0.extensions.FloatingIPPoolApi;
+import org.jclouds.openstack.nova.v2_0.extensions.VolumeAttachmentApi;
 import org.jclouds.openstack.nova.v2_0.features.FlavorApi;
 import org.jclouds.openstack.nova.v2_0.features.ServerApi;
 import org.jclouds.openstack.nova.v2_0.options.CreateServerOptions;
+import org.jclouds.openstack.nova.v2_0.predicates.ServerPredicates;
 import org.jclouds.openstack.v2_0.domain.PaginatedCollection;
 import org.jclouds.openstack.v2_0.domain.Resource;
 import org.jclouds.openstack.v2_0.options.PaginationOptions;
@@ -51,6 +63,8 @@ import static com.cloudera.director.openstack.nova.NovaInstanceTemplateConfigura
 import static com.cloudera.director.openstack.nova.NovaInstanceTemplateConfigurationProperty.AVAILABILITY_ZONE;
 import static com.cloudera.director.openstack.nova.NovaInstanceTemplateConfigurationProperty.KEY_NAME;
 import static com.cloudera.director.openstack.nova.NovaInstanceTemplateConfigurationProperty.FLOATING_IP_POOL;
+import static com.cloudera.director.openstack.nova.NovaInstanceTemplateConfigurationProperty.VOLUME_NUMBER;
+import static com.cloudera.director.openstack.nova.NovaInstanceTemplateConfigurationProperty.VOLUME_SIZE;
 
 import com.cloudera.director.openstack.OpenStackCredentials;
 import com.cloudera.director.spi.v1.compute.util.AbstractComputeProvider;
@@ -83,7 +97,9 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 	private static final Logger LOG = LoggerFactory.getLogger(NovaProvider.class);
 	
 	private static final ApiMetadata NOVA_API_METADATA = new NovaApiMetadata();
-	
+	private static final ApiMetadata CINDER_API_METADATA = new CinderApiMetadata();
+
+	private static final String VOLUME_DESCRIPTION = "SSD";
 	/**
 	 * The provider configuration properties.
 	 */	
@@ -126,10 +142,14 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 	private final NovaApi novaApi;
 	
 	/*
+	 * The cinder api for OpenStack Cinder service
+	 */
+	private final CinderApi cinderApi;
+
+	/*
 	 * Region of the provider
 	 */
 	private String region;
-	
 	
 	public NovaProvider(Configured configuration, OpenStackCredentials credentials,
 			Config openstackConfig, LocalizationContext localizationContext) {
@@ -137,6 +157,7 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 		this.credentials = credentials;
 		this.openstackConfig = openstackConfig;
 		this.novaApi = buildNovaAPI();
+		this.cinderApi = buildCinderAPI();
 		this.region = configuration.getConfigurationValue(REGION, localizationContext);
 	}
 	
@@ -144,23 +165,38 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 		return novaApi;
 	}
 	
+	public CinderApi getCinderApi() {
+		return cinderApi;
+	}
+
 	public String getRegion() {
 		return region;
 	}
 	
-	
-	private NovaApi buildNovaAPI() {	
+	private NovaApi buildNovaAPI() {
+		Iterable<Module> modules = ImmutableSet.<Module>of(new SLF4JLoggingModule());
+		String endpoint = credentials.getEndpoint();
+		String identity = credentials.getIdentity();
+		String credential = credentials.getCredential();
+
+		return ContextBuilder.newBuilder(NOVA_API_METADATA)
+			  .endpoint(endpoint)
+			  .credentials(identity, credential)
+			  .modules(modules)
+			  .buildApi(NovaApi.class);
+	}
+
+	private CinderApi buildCinderAPI() {
 		Iterable<Module> modules = ImmutableSet.<Module>of(new SLF4JLoggingModule());
 		String endpoint = credentials.getEndpoint();
 		String identity = credentials.getIdentity();
 		String credential = credentials.getCredential();
 		
-		
-		return ContextBuilder.newBuilder(NOVA_API_METADATA)
-				.endpoint(endpoint)
-				.credentials(identity, credential)
-				.modules(modules)
-				.buildApi(NovaApi.class);
+		return ContextBuilder.newBuilder(CINDER_API_METADATA)
+			  .endpoint(endpoint)
+			  .credentials(identity, credential)
+			  .modules(modules)
+			  .buildApi(CinderApi.class);
 	}
 	
 	public NovaInstanceTemplate createResourceTemplate(String name,
@@ -168,12 +204,37 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 		return new NovaInstanceTemplate(name, configuration, tags, this.getLocalizationContext());
 	}
 	
-	
-	private void createAndAssignFloatingIP(FloatingIPApi floatingIpApi,
-			String floatingipPool, String instanceId) {
-		if (floatingipPool != null) {
-	            FloatingIP floatingip = floatingIpApi.allocateFromPool(floatingipPool);
-        	    floatingIpApi.addToServer(floatingip.getIp(), instanceId);
+	private FloatingIP createAndAssignFloatingIP(FloatingIPApi floatingIpApi,
+			String floatingIpPool, String instanceId) {
+		PluginExceptionConditionAccumulator accumulator = new PluginExceptionConditionAccumulator();
+		try {
+			FloatingIP floatingIp = floatingIpApi.allocateFromPool(floatingIpPool);
+			String fltip = floatingIp.getIp();
+			int retryNum = 10;
+			// We need to check whether floating IP was created.
+			while (fltip.isEmpty() && retryNum > 0) {
+				TimeUnit.SECONDS.sleep(5);
+				fltip = floatingIp.getIp();
+				retryNum--;
+			}
+			floatingIpApi.addToServer(fltip, instanceId);
+			// AddToServer does not have return value, so we have to check whether 
+			// floating IP was successfully associated.
+			while (floatingIp.getInstanceId() == null || floatingIp.getInstanceId().isEmpty()) {
+				TimeUnit.SECONDS.sleep(5);
+				floatingIpApi.addToServer(fltip, instanceId);
+				retryNum--;
+			}
+			if (fltip.isEmpty() || floatingIp.getInstanceId() == null ||
+					floatingIp.getInstanceId().isEmpty() ||
+					!floatingIp.getInstanceId().equals(instanceId) ) {
+				floatingIpApi.delete(floatingIp.getId());
+				return null;
+			}
+			return floatingIp;
+		} catch (Exception e) {
+			accumulator.addError(null, e.getMessage());
+			return null;
 		}
 	}
 
@@ -184,9 +245,14 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 				SimpleResourceTemplate.getTemplateLocalizationContext(providerLocalizationContext);
 		
 		// Provisioning the cluster
-		ServerApi  serverApi = novaApi.getServerApi(region);
-		Optional<FloatingIPApi> floatingIpApi = novaApi.getFloatingIPApi(region);
+		NovaApi novaApi = getNovaApi();
+		CinderApi cinderApi = getCinderApi();
+		String region = getRegion();
+		ServerApi serverApi = novaApi.getServerApi(region);
+
 		final Set<String> instancesWithNoPrivateIp = Sets.newHashSet();
+		final Set<String> instancesWithPrivateIp = Sets.newHashSet();
+		final Set<String> floatingIps = Sets.newHashSet();
 		
 		String image = template.getConfigurationValue(IMAGE, templateLocalizationContext);
 		String flavorName = template.getConfigurationValue(TYPE, templateLocalizationContext);
@@ -194,10 +260,44 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 		String azone = template.getConfigurationValue(AVAILABILITY_ZONE, templateLocalizationContext);
 		String securityGroups = template.getConfigurationValue(SECURITY_GROUP_NAMES, templateLocalizationContext);
 		String keyName = template.getConfigurationValue(KEY_NAME, templateLocalizationContext);
-		String floatingipPool = template.getConfigurationValue(FLOATING_IP_POOL, templateLocalizationContext);
+		String floatingIpPool = template.getConfigurationValue(FLOATING_IP_POOL, templateLocalizationContext);
 		List<String> securityGroupNames = NovaInstanceTemplate.CSV_SPLITTER.splitToList(securityGroups);
+		int volumeNumber = Integer.parseInt(template.getConfigurationValue(VOLUME_NUMBER, templateLocalizationContext));
+		int volumeSize = Integer.parseInt(template.getConfigurationValue(VOLUME_SIZE, templateLocalizationContext));
 		String flavorId = getFlavorIDByName(flavorName);
-		
+
+		if (volumeNumber > 0 && volumeSize > 0) {
+			// If volume number and volume size are > 0, we will verify whether
+			// VolumeAttachmentApi presents. If not we will not continue.
+			Optional<VolumeAttachmentApi> volumeAttApi = novaApi.getVolumeAttachmentApi(region);
+			if (!volumeAttApi.isPresent()) {
+				throw new UnrecoverableProviderException("Volume Attachment API does not exist.");
+			}			
+		}
+		if (floatingIpPool != null && !floatingIpPool.isEmpty()) {
+			// If floatingIpPool is not empty, verify whether
+			// floatingIpApi and flotingipPool present. If not we will not continue.
+			Optional<FloatingIPApi> floatingIpApi = novaApi.getFloatingIPApi(region);
+			if (!floatingIpApi.isPresent()) {
+				throw new UnrecoverableProviderException("FloatingIp API does not exist.");
+			}
+			Optional<FloatingIPPoolApi> floatingIpPoolApi = novaApi.getFloatingIPPoolApi(region);
+			if (!floatingIpPoolApi.isPresent()) {
+				throw new UnrecoverableProviderException("FloatingIpPool API does not exist.");
+			}
+			FluentIterable<? extends FloatingIPPool> fltIpPool = floatingIpPoolApi.get().list();
+			boolean poolExists = false;
+			for (FloatingIPPool pool : fltIpPool) {
+				if (pool.getName().equals(floatingIpPool)) {
+					poolExists = true;
+					break;
+				}
+			}
+			if (!poolExists) {
+				throw new UnrecoverableProviderException("FloatingIpPool does not exist.");
+			}
+		}
+
 		for (String currentId : instanceIds) {
 			String decoratedInstanceName = decorateInstanceName(template, currentId, templateLocalizationContext);
 
@@ -205,7 +305,9 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 			Map<String, String> tags = new HashMap<String, String>();
 			tags.put("DIRECTOR_ID", currentId);
 			tags.put("INSTANCE_NAME", decoratedInstanceName);
-			
+			tags.put("VOLUME_NUMBER", Integer.toString(volumeNumber));
+			tags.put("VOLUME_SIZE", Integer.toString(volumeSize));
+
 			CreateServerOptions createServerOps = new CreateServerOptions()
 								.keyPairName(keyName)
 								.networks(network)
@@ -215,7 +317,7 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 			
 			ServerCreated currentServer = serverApi.create(decoratedInstanceName, image, flavorId, createServerOps);
 			
-			String novaInstanceId = currentServer.getId();			
+			String novaInstanceId = currentServer.getId();
 			while (novaInstanceId.isEmpty()) {
 				TimeUnit.SECONDS.sleep(5);
 				novaInstanceId = currentServer.getId();
@@ -224,8 +326,16 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 			if (serverApi.get(novaInstanceId).getAddresses() == null) {
 				instancesWithNoPrivateIp.add(novaInstanceId);
 			} else {
-				createAndAssignFloatingIP(floatingIpApi.get(), floatingipPool, novaInstanceId);
+				if (floatingIpPool != null && !floatingIpPool.isEmpty()) {
+					// We already check floatingIpApi exists above. So the get will not fail.
+					FloatingIPApi floatingIpApi = novaApi.getFloatingIPApi(region).get();
+					FloatingIP fltip = createAndAssignFloatingIP(floatingIpApi, floatingIpPool, novaInstanceId);
+					if (fltip != null) {
+						floatingIps.add(fltip.getId());
+					}
+				}
 				LOG.info("<< Instance {} got IP {}", novaInstanceId, serverApi.get(novaInstanceId).getAccessIPv4());
+				instancesWithPrivateIp.add(novaInstanceId);
 			}
 		}
 		
@@ -236,11 +346,18 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 		while (!instancesWithNoPrivateIp.isEmpty() && !timeoutExceeded) {
 			LOG.info(">> Waiting for {} instance(s) to be active",
 					instancesWithNoPrivateIp.size());
-		    
+			
 			for (String novaInstanceId : instancesWithNoPrivateIp) {
 				if (serverApi.get(novaInstanceId).getAddresses() != null) {
 					instancesWithNoPrivateIp.remove(novaInstanceId);
-					createAndAssignFloatingIP(floatingIpApi.get(), floatingipPool, novaInstanceId);
+					instancesWithPrivateIp.add(novaInstanceId);
+					if (floatingIpPool != null && !floatingIpPool.isEmpty()) {
+						FloatingIPApi floatingIpApi = novaApi.getFloatingIPApi(region).get();
+						FloatingIP fltip = createAndAssignFloatingIP(floatingIpApi, floatingIpPool, novaInstanceId);
+						if (fltip != null) {
+							floatingIps.add(fltip.getId());
+						}
+					}
 				}
 			}
 			
@@ -250,14 +367,19 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 				
 				if (totalTimePollingSeconds > pollingTimeoutSeconds) {
 					timeoutExceeded = true;
-		        }        
+				}
 				TimeUnit.SECONDS.sleep(5);
 				totalTimePollingSeconds += 5;
 			}
 		}
 		
 		int successfulOperationCount = instanceIds.size() - instancesWithNoPrivateIp.size();
+		if (floatingIpPool != null && !floatingIpPool.isEmpty()) {
+			successfulOperationCount = Math.min(successfulOperationCount, floatingIps.size());
+		}
 		if (successfulOperationCount < minCount) {
+			// Instance number does not meet the requirement. Delete instances
+			// and floating IPs if existing.
 			PluginExceptionConditionAccumulator accumulator = new PluginExceptionConditionAccumulator();
 			BiMap<String, String> virtualInstanceIdsByNovaInstanceId = 
 					getNovaInstanceIdsByVirtualInstanceId(instanceIds);
@@ -265,19 +387,132 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 			for (String currentId : instanceIds) {
 				try{
 					String novaInstanceId = virtualInstanceIdsByNovaInstanceId.get(currentId);
-					novaApi.getServerApi(region).delete(novaInstanceId);
+					serverApi.delete(novaInstanceId);
 				} catch (Exception e) {
 					accumulator.addError(null, e.getMessage());
+				}
+			}
+			if (floatingIpPool != null && !floatingIpPool.isEmpty()) {
+				FloatingIPApi floatingIpApi = novaApi.getFloatingIPApi(region).get();
+				for (String fltId : floatingIps) {
+					try{
+						floatingIpApi.delete(fltId);
+					} catch (Exception e) {
+						accumulator.addError(null, e.getMessage());
+					}
 				}
 			}
 			PluginExceptionDetails pluginExceptionDetails = new PluginExceptionDetails(accumulator.getConditionsByKey());
 			throw new UnrecoverableProviderException("Problem allocating instances.", pluginExceptionDetails);
 		}
+		if (volumeNumber > 0 && volumeSize > 0 && instancesWithPrivateIp.size() > 0) {
+			// Need to allocate volumes for instances.
+			// Wait all instances to be in "ACTIVE" status.
+			for (String insId : instancesWithPrivateIp) {
+				ServerPredicates.awaitStatus(serverApi, Status.ACTIVE, 120, 5).apply(insId);
+			}
+			
+			LOG.info("Need to allocate {} volumes for each instances.", volumeNumber);
+			
+			VolumeApi volumeApi = cinderApi.getVolumeApi(region);
+			// We have already confirmed volumeAttApi exists, so get will not fail.
+			VolumeAttachmentApi volumeAttachApi = novaApi.getVolumeAttachmentApi(region).get();
+			final List<String> volumeIds = new ArrayList<String>();
+			
+			//Create all volumes before attaching them to save time.
+			int vol_to_create = volumeNumber * instancesWithPrivateIp.size();
+			LOG.info(">> Start to create {} volumes for the instances.", vol_to_create);
+			for (int i = 0; i < vol_to_create; i++) {
+				CreateVolumeOptions createVolOps = CreateVolumeOptions.Builder
+						.description(VOLUME_DESCRIPTION)
+						.availabilityZone(azone);
+				Volume currentVolume = volumeApi.create(volumeSize, createVolOps);
+				volumeIds.add(currentVolume.getId());
+			}
+			
+			LOG.info(">> Waiting for {} instance(s) to be attached by volumes.",
+					instancesWithPrivateIp.size());
+			final List<String> activeVolIds = new ArrayList<String>();
+			for (String insId: instancesWithPrivateIp) {				
+				for (int i = 0; i < volumeNumber; i++) {
+					// Get the first volume, and shift the list.
+					String volId = volumeIds.get(0);
+					volumeIds.remove(volId);
+					// We do not set the device so that the devices could be set automatically.
+					String device = "";
+					Volume currentVolume = volumeApi.get(volId);
+					// Wait until Available. The default awaitAvailable wait time is too long (10min).
+					// If not success, we delete it, and regenerate a new volId.
+					boolean createdSuccess = false;
+					if (VolumePredicates.awaitStatus(volumeApi, Volume.Status.AVAILABLE, 60, 5).apply(currentVolume)) {
+						activeVolIds.add(volId);
+						createdSuccess = true;
+					}
+					else{
+						boolean volDeleted = volumeApi.delete(volId);
+						if (volDeleted) {
+							CreateVolumeOptions createVolOps = CreateVolumeOptions.Builder
+									.description(VOLUME_DESCRIPTION)
+									.availabilityZone(azone);
+							currentVolume = volumeApi.create(volumeSize, createVolOps);
+							volId = currentVolume.getId();
+							if (VolumePredicates.awaitStatus(volumeApi, Volume.Status.AVAILABLE, 60, 5).apply(currentVolume)) {
+								activeVolIds.add(volId);
+								createdSuccess = true;
+							}
+						}
+					}
+					if (!createdSuccess) {
+						// Delete the volume. Instance will be deleted later.
+						volumeApi.delete(volId);
+						instancesWithPrivateIp.remove(insId);
+						LOG.info("Time out on Volume: " + volId);
+					}
+					else {
+						volumeAttachApi.attachVolumeToServerAsDevice(volId, insId, device);
+						// Wait until In-use.
+						if (!VolumePredicates.awaitStatus(volumeApi, Volume.Status.IN_USE, 60, 5).apply(currentVolume)) {
+							// Attach fail. Delete the volume. Instance will be deleted later.
+							boolean volDeleted = volumeApi.delete(volId);
+							if (volDeleted) {
+								activeVolIds.remove(volId);
+							}
+							instancesWithPrivateIp.remove(insId);
+							LOG.info("Time out on Volume: " + volId);
+						}
+					}
+				}
+			}
+			//if instances with private IP and volumes do not meet the minCount, delete all of them.
+			if (instancesWithPrivateIp.size() < minCount) {
+				PluginExceptionConditionAccumulator accumulator = new PluginExceptionConditionAccumulator();
+				BiMap<String, String> virtualInstanceIdsByNovaInstanceId =
+						getNovaInstanceIdsByVirtualInstanceId(instanceIds);
+
+				for (String currentId : instanceIds) {
+					try{
+						String novaInstanceId = virtualInstanceIdsByNovaInstanceId.get(currentId);
+						serverApi.delete(novaInstanceId);
+					} catch (Exception e) {
+						accumulator.addError(null, e.getMessage());
+					}
+				}
+				for (String volId: activeVolIds) {
+					try{
+						volumeApi.delete(volId);
+					} catch (Exception e) {
+						accumulator.addError(null, e.getMessage());
+					}
+				}
+				PluginExceptionDetails pluginExceptionDetails = new PluginExceptionDetails(accumulator.getConditionsByKey());
+				throw new UnrecoverableProviderException("Problem allocating instances and volumes.", pluginExceptionDetails);
+			}
+		}
 	}
 	
 	private String findFloatingIPByAddress(FloatingIPApi floatingIpApi, String floatingIp) {
 		FluentIterable<FloatingIP> floatingipList = floatingIpApi.list();
-		for (FloatingIP ip : floatingipList) {
+		for ( FloatingIP ip : floatingipList) {
 			if (ip.getIp().compareTo(floatingIp) == 0) {
 				return ip.getId();
 			}
@@ -286,6 +521,8 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 	}
 
 	private String getFlavorIDByName(String flavorName) {
+		NovaApi novaApi = getNovaApi();
+		String region = getRegion();
 		FlavorApi flavorApi = novaApi.getFlavorApi(region);
 		FluentIterable<Resource> flavorList = flavorApi.list().concat();
 		for (Resource flavor : flavorList) {
@@ -295,22 +532,51 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 		}
 		return null; 
 	}
-	
+
 	public void delete(NovaInstanceTemplate template, Collection<String> virtualInstanceIds)
 			throws InterruptedException {
 		if (virtualInstanceIds.isEmpty()) {
 			return;
 		}
 		
+		LocalizationContext providerLocalizationContext = getLocalizationContext();
+		LocalizationContext templateLocalizationContext =
+			SimpleResourceTemplate.getTemplateLocalizationContext(providerLocalizationContext);
+		int volumeNumber = Integer.parseInt(template.getConfigurationValue(VOLUME_NUMBER, templateLocalizationContext));
+
+		NovaApi novaApi = getNovaApi();
+		CinderApi cinderApi = getCinderApi();
+		String region = getRegion();
 		BiMap<String, String> virtualInstanceIdsByNovaInstanceId = 
 				getNovaInstanceIdsByVirtualInstanceId(virtualInstanceIds);
-		
-		ServerApi serverApi = novaApi.getServerApi(region);
-		Optional<FloatingIPApi> floatingIpApi = novaApi.getFloatingIPApi(region);
-		
+
+		Set<String> novaIds = Sets.newHashSet();
 		for (String currentId : virtualInstanceIds) {
 			String novaInstanceId = virtualInstanceIdsByNovaInstanceId.get(currentId);
-			
+			novaIds.add(novaInstanceId);
+		}
+
+		// Get all volumes attached to the instances.
+		Set<String> volumeIds = Sets.newHashSet();
+		if (volumeNumber > 0) {
+			Optional<VolumeAttachmentApi> volumeAttApi = novaApi.getVolumeAttachmentApi(region);
+			if (!volumeAttApi.isPresent()) {
+				throw new UnrecoverableProviderException("Volume Attachment APIs do not exist.");
+			}
+			VolumeAttachmentApi volumeAttachApi = volumeAttApi.get();
+			for (String novaId : novaIds) {
+				FluentIterable<VolumeAttachment> vol_attachs = volumeAttachApi.listAttachmentsOnServer(novaId);
+				for (VolumeAttachment vol_attach : vol_attachs) {
+					volumeIds.add(vol_attach.getVolumeId());
+				}
+			}
+		}
+
+		ServerApi serverApi = novaApi.getServerApi(region);
+		Optional<FloatingIPApi> floatingIpApi = novaApi.getFloatingIPApi(region);
+
+		for (String currentId : virtualInstanceIds) {
+			String novaInstanceId = virtualInstanceIdsByNovaInstanceId.get(currentId);
 			//find the floating IP address if it exists
 			String floatingIp = null;
 			Iterator<Address> iterator = serverApi.get(novaInstanceId).getAddresses().values().iterator();
@@ -321,18 +587,47 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 					floatingIp = iterator.next().getAddr();
 				}
 			}
-			
-			//disassociate and delete the floating IP
-			if (floatingIp != null) {
-				String floatingipID = findFloatingIPByAddress(floatingIpApi.get(), floatingIp);
-				floatingIpApi.get().removeFromServer(floatingIp, novaInstanceId);
-				floatingIpApi.get().delete(floatingipID);
+
+			// Disassociate and delete the floating IP.
+			if (floatingIp != null && !floatingIp.isEmpty()) {
+				if (floatingIpApi.isPresent()) {
+					String floatingipID = findFloatingIPByAddress(floatingIpApi.get(), floatingIp);
+					floatingIpApi.get().removeFromServer(floatingIp, novaInstanceId);
+					floatingIpApi.get().delete(floatingipID);
+				}
 			}
 			
-			//delete the server
+			// Delete the server
 			boolean deleted = serverApi.delete(novaInstanceId);
 			if (!deleted) {
 				LOG.info("Unable to terminate instance {}", novaInstanceId);
+			}
+		}
+		
+		// Delete the volumes.
+		if (volumeIds.size() > 0) {
+			Set<Volume> volumes = Sets.newHashSet();
+			VolumeApi  volumeApi = cinderApi.getVolumeApi(region);
+			for (String volId : volumeIds) {
+				// Wait until volumes available.
+				Volume currentVolume = volumeApi.get(volId);
+				if (!VolumePredicates.awaitStatus(volumeApi, Volume.Status.AVAILABLE, 60, 5).apply(currentVolume)) {
+					LOG.info("Volume {} is not ready for delete.", currentVolume.getId());
+				}
+				else {
+					volumes.add(currentVolume);
+					// Delete the volume.
+					boolean deleted = volumeApi.delete(volId);
+					if (!deleted) {
+						LOG.info("Unable to delete volume {}.", currentVolume.getId());
+					}
+				}
+			}
+			for (Volume currentVolume : volumes) {
+				// Wait until the volume deleted.
+				if (!VolumePredicates.awaitDeleted(volumeApi).apply(currentVolume)) {
+					LOG.info("Unable to delete volume {}.", currentVolume.getId());
+				}
 			}
 		}
 	}
@@ -340,6 +635,9 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 	public Collection<NovaInstance> find(NovaInstanceTemplate template,
 			Collection<String> virtualInstanceIds) throws InterruptedException {
 		
+		NovaApi novaApi = getNovaApi();
+		String region = getRegion();
+
 		final Collection<NovaInstance> novaInstances =
 				Lists.newArrayListWithExpectedSize(virtualInstanceIds.size());
 		BiMap<String, String> virtualInstanceIdsByNovaInstanceId = 
@@ -357,6 +655,9 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 
 	public Map<String, InstanceState> getInstanceState(NovaInstanceTemplate template, 
 			Collection<String> virtualInstanceIds) {
+
+		NovaApi novaApi = getNovaApi();
+		String region = getRegion();
 		
 		Map<String, InstanceState> instanceStateByInstanceId = new HashMap<String, InstanceState >();
 		
@@ -383,7 +684,7 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 	}
 	
 	private static String decorateInstanceName(NovaInstanceTemplate template, String currentId,
-		      LocalizationContext templateLocalizationContext){
+			  LocalizationContext templateLocalizationContext){
 		return template.getInstanceNamePrefix() + "-" + currentId;
 	}
 	
@@ -395,7 +696,10 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 	 * @return the map from virtual instance ID to corresponding Nova instance ID
 	 */
 	private BiMap<String, String> getNovaInstanceIdsByVirtualInstanceId(
-	      Collection<String> virtualInstanceIds) {
+		  Collection<String> virtualInstanceIds) {
+
+		NovaApi novaApi = getNovaApi();
+		String region = getRegion();
 		final BiMap<String, String> novaInstanceIdsByVirtualInstanceId = HashBiMap.create();
 		for (String instanceName : virtualInstanceIds) {
 			ListMultimap<String, String> multimap = ArrayListMultimap.create();
@@ -411,3 +715,4 @@ public class NovaProvider extends AbstractComputeProvider<NovaInstance, NovaInst
 		return novaInstanceIdsByVirtualInstanceId;
 	}
 }
+

--- a/src/main/java/com/cloudera/director/openstack/nova/NovaProviderConfigurationProperty.java
+++ b/src/main/java/com/cloudera/director/openstack/nova/NovaProviderConfigurationProperty.java
@@ -24,12 +24,12 @@ import com.cloudera.director.spi.v1.model.util.SimpleConfigurationPropertyBuilde
  */
 public enum NovaProviderConfigurationProperty implements ConfigurationPropertyToken{
 	 REGION(new SimpleConfigurationPropertyBuilder()
-     .configKey("region")
-     .name("Region")
-     .required(true)
-     .defaultValue("regionOne")
-     .defaultDescription("Region to target for deployment.")
-     .build());
+	 .configKey("region")
+	 .name("Region")
+	 .required(true)
+	 .defaultValue("regionOne")
+	 .defaultDescription("Region to target for deployment.")
+	 .build());
 
 	/**
 	 * The configuration property.
@@ -42,7 +42,7 @@ public enum NovaProviderConfigurationProperty implements ConfigurationPropertyTo
 	 * @param configurationProperty the configuration property
 	 */
 	private NovaProviderConfigurationProperty(ConfigurationProperty configurationProperty) {
-	    this.configurationProperty = configurationProperty;
+		this.configurationProperty = configurationProperty;
 	}
 	
 	@Override
@@ -52,3 +52,4 @@ public enum NovaProviderConfigurationProperty implements ConfigurationPropertyTo
 
 
 }
+

--- a/src/main/java/com/cloudera/director/openstack/nova/NovaProviderConfigurationValidator.java
+++ b/src/main/java/com/cloudera/director/openstack/nova/NovaProviderConfigurationValidator.java
@@ -50,19 +50,18 @@ public class NovaProviderConfigurationValidator implements ConfigurationValidato
 	public NovaProviderConfigurationValidator(OpenStackCredentials credentials) {
 		this.credentials = credentials;
 	}
-    @Override 
+	@Override
 	public void validate(String name, Configured configuration,
 			PluginExceptionConditionAccumulator accumulator, LocalizationContext localizationContext) {
 		checkRegion(configuration, accumulator, localizationContext);
 	}
 	
-    /**
-     * Validates the configured region.
-     * 
-     * @param configuration the configuration to be validated
-     * @param accumulator the exception condition accumulator
-     * @param localizationContext the localization context
-     */
+	/**
+	 * Validates the configured region.
+	 * @param configuration the configuration to be validated
+	 * @param accumulator the exception condition accumulator
+	 * @param localizationContext the localization context
+	 */
 	void checkRegion(Configured configuration,
 			PluginExceptionConditionAccumulator accumulator,
 			LocalizationContext localizationContext) {
@@ -75,9 +74,9 @@ public class NovaProviderConfigurationValidator implements ConfigurationValidato
 		
 		NovaApi novapi = ContextBuilder.newBuilder(new NovaApiMetadata())
 				  .endpoint(endpoint)
-	              .credentials(identity, credential)
-	              .modules(modules)
-	              .buildApi(NovaApi.class);
+				  .credentials(identity, credential)
+				  .modules(modules)
+				  .buildApi(NovaApi.class);
 		if (!novapi.getConfiguredRegions().contains(regionName)) {
 			addError(accumulator, REGION, localizationContext, null, REGION_NOT_FOUND_MSG, regionName);
 		}	
@@ -85,3 +84,4 @@ public class NovaProviderConfigurationValidator implements ConfigurationValidato
 	}
 
 }
+


### PR DESCRIPTION
In this version, we mainly implemented the feature of cinder support for
OpenStack Plugin. We finished this by:
1. adding VOLUME_NUM and VOLUME_SIZE parameters in the template.
2. while VOLUME_NUM and VOLUME_SIZE are both > 0, in allocate method, we will
  allocate and attch cinder volumes to the instance by VolumeApi and
  VolumeAttachmentApi.
3. while VOLUME_NUM and VOLUME_SIZE are both > 0, in delete method, we will
  delete the volumes after the instances are deleted (so that we do not need
  to detach the volume).
4. we add some validating codes and retry codes for above code rubostness.
Other than the above changes, we also change some code to improve the
rubostness of the other part. E.g., we add some validating and retry codes
for floating IP creating and associating, which was proved to be able to avoid
some unexpected issues like no IP allocated or IP not associated properly.