### PR TITLE
Add Nova Idempotency Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<--
+<!--
  * Copyright (c) 2015 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -122,6 +122,11 @@
 			<artifactId>openstack-trove</artifactId>
 			<version>${jclouds.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.jclouds.api</groupId>
+			<artifactId>openstack-cinder</artifactId>
+			<version>${jclouds.version}</version>
+		</dependency>
 
 		<!-- test dependencies -->
 		<dependency>
@@ -148,12 +153,12 @@
 			<version>${logback.version}</version>
 			<scope>test</scope>
 		</dependency>
-               <dependency>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-core</artifactId>
-                        <version>${logback.version}</version>
-                        <scope>test</scope>
-                </dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-core</artifactId>
+			<version>${logback.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<repositories>
@@ -289,7 +294,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${maven-surefire-plugin.version}</version>
 				<configuration>
-					<skip>true</skip>
+					<skip>false</skip>
 					<systemPropertyVariables>
 						<KEYSTONE_ENDPOINT>http://127.0.0.1:5000/v2.0/</KEYSTONE_ENDPOINT>
 						<TENANT_NAME>admin</TENANT_NAME>
@@ -313,6 +318,14 @@
 				<configuration>
 					<excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
 					<failOnError>false</failOnError>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/com/cloudera/director/openstack/Configurations.java
+++ b/src/main/java/com/cloudera/director/openstack/Configurations.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.cloudera.director.openstack;
 
 

--- a/src/main/java/com/cloudera/director/openstack/OpenStackCredentials.java
+++ b/src/main/java/com/cloudera/director/openstack/OpenStackCredentials.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.cloudera.director.openstack;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/com/cloudera/director/openstack/OpenStackCredentialsProvider.java
+++ b/src/main/java/com/cloudera/director/openstack/OpenStackCredentialsProvider.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.cloudera.director.openstack;
 
 import java.util.List;
@@ -55,4 +56,3 @@ public class OpenStackCredentialsProvider implements CredentialsProvider<OpenSta
 	}
 
 }
-

--- a/src/main/java/com/cloudera/director/openstack/OpenStackCredentialsProviderConfigurationProperty.java
+++ b/src/main/java/com/cloudera/director/openstack/OpenStackCredentialsProviderConfigurationProperty.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.cloudera.director.openstack;
 
 import com.cloudera.director.spi.v1.model.ConfigurationProperty;

--- a/src/main/java/com/cloudera/director/openstack/OpenStackLauncher.java
+++ b/src/main/java/com/cloudera/director/openstack/OpenStackLauncher.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.cloudera.director.openstack;
 
 import java.io.File;

--- a/src/main/java/com/cloudera/director/openstack/OpenStackProvider.java
+++ b/src/main/java/com/cloudera/director/openstack/OpenStackProvider.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.cloudera.director.openstack;
 
 import java.util.Arrays;

--- a/src/main/java/com/cloudera/director/openstack/nova/NovaInstance.java
+++ b/src/main/java/com/cloudera/director/openstack/nova/NovaInstance.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.cloudera.director.openstack.nova;
 
 import java.net.InetAddress;

--- a/src/main/java/com/cloudera/director/openstack/nova/NovaInstanceState.java
+++ b/src/main/java/com/cloudera/director/openstack/nova/NovaInstanceState.java
@@ -1,5 +1,20 @@
-package com.cloudera.director.openstack.nova;
+/*
+ * Copyright (c) 2015 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+package com.cloudera.director.openstack.nova;
 
 import java.util.Collections;
 import java.util.Map;
@@ -9,7 +24,6 @@ import org.jclouds.openstack.nova.v2_0.domain.Server.Status;
 import com.cloudera.director.spi.v1.model.InstanceStatus;
 import com.cloudera.director.spi.v1.model.util.AbstractInstanceState;
 import com.google.common.collect.Maps;
-
 
 /**
  * Nova instance state implementation

--- a/src/main/java/com/cloudera/director/openstack/nova/NovaInstanceTemplate.java
+++ b/src/main/java/com/cloudera/director/openstack/nova/NovaInstanceTemplate.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.cloudera.director.openstack.nova;
 
 import java.util.List;

--- a/src/main/java/com/cloudera/director/openstack/nova/NovaInstanceTemplateConfigurationProperty.java
+++ b/src/main/java/com/cloudera/director/openstack/nova/NovaInstanceTemplateConfigurationProperty.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.cloudera.director.openstack.nova;
 
 import com.cloudera.director.spi.v1.compute.ComputeInstanceTemplate.ComputeInstanceTemplateConfigurationPropertyToken;
@@ -104,7 +105,7 @@ public enum NovaInstanceTemplateConfigurationProperty implements ConfigurationPr
 	FLOATING_IP_POOL(new SimpleConfigurationPropertyBuilder()
 			.configKey("floatingIpPoolName")
 			.name("FloatingIP pool name")
-			.defaultValue(null)
+			.defaultValue("")
 			.widget(ConfigurationProperty.Widget.TEXT)
 			.defaultDescription(
 				"The floating IP pool from which to allocate flaoting IP. "+
@@ -116,7 +117,7 @@ public enum NovaInstanceTemplateConfigurationProperty implements ConfigurationPr
 	 * The number of volumes to be attached to each new instance.
 	 */
 	VOLUME_NUMBER(new SimpleConfigurationPropertyBuilder()
-			 .configKey("volumeNumber")
+			.configKey("volumeNumber")
 			.name("Volume number")
 			.required(false)
 			.widget(ConfigurationProperty.Widget.NUMBER)

--- a/src/main/java/com/cloudera/director/openstack/nova/NovaProviderConfigurationProperty.java
+++ b/src/main/java/com/cloudera/director/openstack/nova/NovaProviderConfigurationProperty.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.cloudera.director.openstack.nova;
 
 import com.cloudera.director.spi.v1.model.ConfigurationProperty;

--- a/src/main/java/com/cloudera/director/openstack/nova/NovaProviderConfigurationValidator.java
+++ b/src/main/java/com/cloudera/director/openstack/nova/NovaProviderConfigurationValidator.java
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.cloudera.director.openstack.nova;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.Set;
 import org.jclouds.ContextBuilder;
 import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
 import org.jclouds.openstack.nova.v2_0.NovaApi;
@@ -53,7 +55,19 @@ public class NovaProviderConfigurationValidator implements ConfigurationValidato
 	@Override
 	public void validate(String name, Configured configuration,
 			PluginExceptionConditionAccumulator accumulator, LocalizationContext localizationContext) {
-		checkRegion(configuration, accumulator, localizationContext);
+		
+		Iterable<Module> modules = ImmutableSet.<Module>of(new SLF4JLoggingModule());
+		String endpoint = credentials.getEndpoint();
+		String identity = credentials.getIdentity();
+		String credential = credentials.getCredential();
+		
+		
+		NovaApi novapi = ContextBuilder.newBuilder(new NovaApiMetadata())
+				  .endpoint(endpoint)
+				  .credentials(identity, credential)
+				  .modules(modules)
+				  .buildApi(NovaApi.class);
+		checkRegion(novapi, configuration, accumulator, localizationContext);
 	}
 	
 	/**
@@ -62,22 +76,14 @@ public class NovaProviderConfigurationValidator implements ConfigurationValidato
 	 * @param accumulator the exception condition accumulator
 	 * @param localizationContext the localization context
 	 */
-	void checkRegion(Configured configuration,
+	void checkRegion(NovaApi novapi,
+			Configured configuration,
 			PluginExceptionConditionAccumulator accumulator,
 			LocalizationContext localizationContext) {
 		String regionName = configuration.getConfigurationValue(REGION, localizationContext);
 		LOG.info(">> Querying Region '{}'", regionName);
-		Iterable<Module> modules = ImmutableSet.<Module>of(new SLF4JLoggingModule());
-		String endpoint = credentials.getEndpoint();
-		String identity = credentials.getIdentity();
-		String credential = credentials.getCredential();
-		
-		NovaApi novapi = ContextBuilder.newBuilder(new NovaApiMetadata())
-				  .endpoint(endpoint)
-				  .credentials(identity, credential)
-				  .modules(modules)
-				  .buildApi(NovaApi.class);
-		if (!novapi.getConfiguredRegions().contains(regionName)) {
+		Set<String> regions = novapi.getConfiguredRegions();
+		if (!regions.contains(regionName)) {
 			addError(accumulator, REGION, localizationContext, null, REGION_NOT_FOUND_MSG, regionName);
 		}	
 		


### PR DESCRIPTION
In this commits, we add the nova idempotency support. This allows us to:
1. run allocate for multiple times by the same parameter (instanceIDs), while only one copy of resources will
   be allocated.
2. delete method will not cause any resource leak. Currently this can only be partially implemented, for we
   can not track floating IPs not associated to instances by former allocate method. So there might be some
   floating IPs not recycled.
We also fix some bugs in this commits.