### PR TITLE
Fix bugs found in scenario tests

### DIFF
--- a/src/main/java/com/cloudera/director/openstack/OpenStackCredentials.java
+++ b/src/main/java/com/cloudera/director/openstack/OpenStackCredentials.java
@@ -51,6 +51,5 @@ public class OpenStackCredentials {
 			   identity.equals(cre.getIdentity()) &&
 			   credential.equals(cre.getCredential());
 	}
-	
 }
 

--- a/src/main/java/com/cloudera/director/openstack/OpenStackProvider.java
+++ b/src/main/java/com/cloudera/director/openstack/OpenStackProvider.java
@@ -52,12 +52,14 @@ public class OpenStackProvider extends AbstractCloudProvider {
 	 * The resource provider metadata.
 	 */
 	private static final List<ResourceProviderMetadata> RESOURCE_PROVIDER_METADATA = featureFlag ? 
-			Collections.unmodifiableList(Arrays.asList(NovaProvider.METADATA, TroveProvider.METADATA)) : Collections.unmodifiableList(Arrays.asList(NovaProvider.METADATA));
+			Collections.unmodifiableList(Arrays.asList(NovaProvider.METADATA, TroveProvider.METADATA)) :
+			Collections.unmodifiableList(Arrays.asList(NovaProvider.METADATA));
 
 	private OpenStackCredentials credentials;
 	private Config openstackConfig;
 
-	protected OpenStackCredentials getOpenStackCredentials(Configured configuration, LocalizationContext localizationContext) {
+	protected OpenStackCredentials getOpenStackCredentials(Configured configuration,
+			LocalizationContext localizationContext) {
 		CredentialsProvider<OpenStackCredentials> provider = new OpenStackCredentialsProvider();
 		OpenStackCredentials credentials = provider.createCredentials(configuration, localizationContext);
 		checkNotNull(credentials, "OpenStackCredentials is null!");
@@ -76,13 +78,15 @@ public class OpenStackProvider extends AbstractCloudProvider {
 			.resourceProviderMetadata(RESOURCE_PROVIDER_METADATA)
 			.build();
 
-	public OpenStackProvider(Configured configuration, Config openstackConfig,LocalizationContext rootLocalizationContext) {
+	public OpenStackProvider(Configured configuration, Config openstackConfig,
+			LocalizationContext rootLocalizationContext) {
 		super(METADATA, rootLocalizationContext);
 		this.openstackConfig = openstackConfig;
 		this.credentials = getOpenStackCredentials(configuration, rootLocalizationContext);
 	}
 
-	protected ConfigurationValidator getResourceProviderConfigurationValidator(ResourceProviderMetadata resourceProviderMetadata) {
+	protected ConfigurationValidator getResourceProviderConfigurationValidator(
+			ResourceProviderMetadata resourceProviderMetadata) {
 		ConfigurationValidator providerSpecificValidator;
 		if (resourceProviderMetadata.getId().equals(NovaProvider.METADATA.getId())) {
 			providerSpecificValidator = new NovaProviderConfigurationValidator(credentials);
@@ -97,10 +101,13 @@ public class OpenStackProvider extends AbstractCloudProvider {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public ResourceProvider createResourceProvider(String resourceProviderId, Configured configuration) {
-		ResourceProviderMetadata resourceProviderMetadata = getProviderMetadata().getResourceProviderMetadata(resourceProviderId);
+	public ResourceProvider createResourceProvider(String resourceProviderId,
+			Configured configuration) {
+		ResourceProviderMetadata resourceProviderMetadata =
+			getProviderMetadata().getResourceProviderMetadata(resourceProviderId);
 		if (resourceProviderMetadata.getId().equals(NovaProvider.METADATA.getId())) {
-			return new NovaProvider(configuration, this.credentials, this.openstackConfig, getLocalizationContext());
+			return new NovaProvider(configuration, this.credentials, this.openstackConfig,
+				getLocalizationContext());
 		}
 
 		if (resourceProviderMetadata.getId().equals(TroveProvider.METADATA.getId())) {

--- a/src/main/java/com/cloudera/director/openstack/nova/NovaInstance.java
+++ b/src/main/java/com/cloudera/director/openstack/nova/NovaInstance.java
@@ -216,9 +216,13 @@ public class NovaInstance
 		try {
 			Iterator<Address> iterator = server.getAddresses().values().iterator();
 			Address address = null;
-			if (iterator.hasNext()) {
+			while (iterator.hasNext()) {
+				// Find the first IPv4 address.
 				address = iterator.next();
-				privateIpAddress = InetAddress.getByName(address.getAddr());
+				if (address.getVersion() == 4) {
+					privateIpAddress = InetAddress.getByName(address.getAddr());
+					break;
+				}
 			}
 		} catch (UnknownHostException e) {
 		  throw new IllegalArgumentException("Invalid private IP address", e);
@@ -238,11 +242,19 @@ public class NovaInstance
 		try {
 			Iterator<Address> iterator = server.getAddresses().values().iterator();
 			Address floatingAddress = null;
-			if (iterator.hasNext()) {
-				iterator.next();
-				if (iterator.hasNext()) {
-					floatingAddress = iterator.next();
+			// Find the first IPv4 address.
+			while (iterator.hasNext()) {
+				Address address = iterator.next();
+				if (address.getVersion() == 4) {
+					break;
+				}
+			}
+			// Find the second IPv4 Address.
+			while (iterator.hasNext()) {
+				floatingAddress = iterator.next();
+				if (floatingAddress.getVersion() == 4) {
 					floatingIpAddress = InetAddress.getByName(floatingAddress.getAddr());
+					break;
 				}
 			}
 		} catch (UnknownHostException e) {

--- a/src/test/java/com/cloudera/director/openstack/nova/NovaProviderTest.java
+++ b/src/test/java/com/cloudera/director/openstack/nova/NovaProviderTest.java
@@ -220,6 +220,7 @@ public class NovaProviderTest {
 		when(flavor.getId()).thenReturn(DEFAULT_FLAVOR_ID);
 		PagedIterable<Resource> flavorList = PagedIterables.onlyPage(IterableWithMarkers.from(Lists.newArrayList(flavor)));
 		when(flavorApi.list()).thenReturn(flavorList);
+		
 	}
 		
 	@Test
@@ -240,6 +241,7 @@ public class NovaProviderTest {
 		ServerCreated servercreated1 = mock(ServerCreated.class);
 		Address address1 = mock(Address.class);
 		when(address1.getAddr()).thenReturn(DEFAULT_PRIVATE_IP1);
+		when(address1.getVersion()).thenReturn(4);
 		Multimap<String, Address> addresses1 = ArrayListMultimap.create();
 		addresses1.put("1", address1);
 		when(servercreated1.getId()).thenReturn(novaInstanceId1);
@@ -256,6 +258,7 @@ public class NovaProviderTest {
 		ServerCreated servercreated2 = mock(ServerCreated.class);
 		Address address2 = mock(Address.class);
 		when(address2.getAddr()).thenReturn(DEFAULT_PRIVATE_IP2);
+		when(address2.getVersion()).thenReturn(4);
 		Multimap<String, Address> addresses2 = ArrayListMultimap.create();
 		addresses2.put("1", address2);
 		when(servercreated2.getId()).thenReturn(novaInstanceId2);
@@ -339,6 +342,7 @@ public class NovaProviderTest {
 		ServerCreated servercreated1 = mock(ServerCreated.class);
 		Address address1 = mock(Address.class);
 		when(address1.getAddr()).thenReturn(DEFAULT_PRIVATE_IP1);
+		when(address1.getVersion()).thenReturn(4);
 		Multimap<String, Address> addresses1 = ArrayListMultimap.create();
 		addresses1.put("1", address1);
 		when(servercreated1.getId()).thenReturn(novaInstanceId1);
@@ -355,6 +359,7 @@ public class NovaProviderTest {
 		ServerCreated servercreated2 = mock(ServerCreated.class);
 		Address address2 = mock(Address.class);
 		when(address2.getAddr()).thenReturn(DEFAULT_PRIVATE_IP2);
+		when(address2.getVersion()).thenReturn(4);
 		Multimap<String, Address> addresses2 = ArrayListMultimap.create();
 		addresses2.put("1", address2);
 		when(servercreated2.getId()).thenReturn(novaInstanceId2);
@@ -397,7 +402,7 @@ public class NovaProviderTest {
 			fail("An exception should have been thrown when we failed to provision at least minCount instances.");
 		} catch (UnrecoverableProviderException e) {
 			LOG.info("Caught: " + e.getMessage());
-			assertThat(e.getMessage()).isEqualTo("Problem allocating instances.");
+			assertThat(e.getMessage()).isEqualTo("Problem allocating 2 instances: Can only get 1 instances with IPs while we want 2.");
 		}
 		
 		//Verify instance creatings was called.
@@ -442,6 +447,7 @@ public class NovaProviderTest {
 		ServerCreated servercreated1 = mock(ServerCreated.class);
 		Address address1 = mock(Address.class);
 		when(address1.getAddr()).thenReturn(DEFAULT_PRIVATE_IP1);
+		when(address1.getVersion()).thenReturn(4);
 		Multimap<String, Address> addresses1 = ArrayListMultimap.create();
 		addresses1.put("1", address1);
 		when(servercreated1.getId()).thenReturn(novaInstanceId1);
@@ -458,6 +464,7 @@ public class NovaProviderTest {
 		ServerCreated servercreated2 = mock(ServerCreated.class);
 		Address address2 = mock(Address.class);
 		when(address2.getAddr()).thenReturn(DEFAULT_PRIVATE_IP2);
+		when(address2.getVersion()).thenReturn(4);
 		Multimap<String, Address> addresses2 = ArrayListMultimap.create();
 		addresses2.put("1", address2);
 		when(servercreated2.getId()).thenReturn(novaInstanceId2);
@@ -539,6 +546,7 @@ public class NovaProviderTest {
 		ServerCreated servercreated1 = mock(ServerCreated.class);
 		Address address1 = mock(Address.class);
 		when(address1.getAddr()).thenReturn(DEFAULT_PRIVATE_IP1);
+		when(address1.getVersion()).thenReturn(4);
 		Multimap<String, Address> addresses1 = ArrayListMultimap.create();
 		addresses1.put("1", address1);
 		when(servercreated1.getId()).thenReturn(novaInstanceId1);
@@ -658,6 +666,7 @@ public class NovaProviderTest {
 		ServerCreated servercreated1 = mock(ServerCreated.class);
 		Address address1 = mock(Address.class);
 		when(address1.getAddr()).thenReturn(DEFAULT_PRIVATE_IP1);
+		when(address1.getVersion()).thenReturn(4);
 		Multimap<String, Address> addresses1 = ArrayListMultimap.create();
 		addresses1.put("1", address1);
 		when(servercreated1.getId()).thenReturn(novaInstanceId1);
@@ -674,6 +683,7 @@ public class NovaProviderTest {
 		ServerCreated servercreated2 = mock(ServerCreated.class);
 		Address address2 = mock(Address.class);
 		when(address2.getAddr()).thenReturn(DEFAULT_PRIVATE_IP2);
+		when(address2.getVersion()).thenReturn(4);
 		Multimap<String, Address> addresses2 = ArrayListMultimap.create();
 		addresses2.put("1", address2);
 		when(servercreated2.getId()).thenReturn(novaInstanceId2);
@@ -806,7 +816,7 @@ public class NovaProviderTest {
 			fail("An exception should have been thrown when we failed to provision at least minCount instances.");
 		} catch (UnrecoverableProviderException e) {
 			LOG.info("Caught: " + e.getMessage());
-			assertThat(e.getMessage()).isEqualTo("Problem allocating instances and volumes.");
+			assertThat(e.getMessage()).isEqualTo("Problem allocating 2 instances: Can only get 1 instances with volumes while we want 2.");
 		}
 		
 		//Verify instance creatings was called.
@@ -865,6 +875,7 @@ public class NovaProviderTest {
 		ServerCreated servercreated1 = mock(ServerCreated.class);
 		Address address1 = mock(Address.class);
 		when(address1.getAddr()).thenReturn(DEFAULT_PRIVATE_IP1);
+		when(address1.getVersion()).thenReturn(4);
 		Multimap<String, Address> addresses1 = ArrayListMultimap.create();
 		addresses1.put("1", address1);
 		when(servercreated1.getId()).thenReturn(novaInstanceId1);
@@ -967,6 +978,7 @@ public class NovaProviderTest {
 
 		Address address1 = mock(Address.class);
 		when(address1.getAddr()).thenReturn(DEFAULT_PRIVATE_IP1);
+		when(address1.getVersion()).thenReturn(4);
 		Multimap<String, Address> addresses1 = ArrayListMultimap.create();
 		addresses1.put("1", address1);
 
@@ -976,6 +988,7 @@ public class NovaProviderTest {
 		
 		Address address2 = mock(Address.class);
 		when(address2.getAddr()).thenReturn(DEFAULT_PRIVATE_IP2);
+		when(address2.getVersion()).thenReturn(4);
 		Multimap<String, Address> addresses2 = ArrayListMultimap.create();
 		addresses2.put("1", address2);
 
@@ -1028,6 +1041,7 @@ public class NovaProviderTest {
 
 		Address address1 = mock(Address.class);
 		when(address1.getAddr()).thenReturn(DEFAULT_PRIVATE_IP1);
+		when(address1.getVersion()).thenReturn(4);
 		Multimap<String, Address> addresses1 = ArrayListMultimap.create();
 		addresses1.put("1", address1);
 
@@ -1266,8 +1280,10 @@ public class NovaProviderTest {
 
 		Address address1 = mock(Address.class);
 		when(address1.getAddr()).thenReturn(DEFAULT_PRIVATE_IP1);
+		when(address1.getVersion()).thenReturn(4);
 		Address floatingAddress1 = mock(Address.class);
 		when(floatingAddress1.getAddr()).thenReturn(DEFAULT_FLOATING_IP1);
+		when(floatingAddress1.getVersion()).thenReturn(4);
 		Multimap<String, Address> addresses1 = ArrayListMultimap.create();
 		addresses1.put("1", address1);
 		addresses1.put("2", floatingAddress1);


### PR DESCRIPTION
We fix below bugs in this patch:
1. When get instance IP, we may get an IPv6 address instead of IPv4, if an IPv6 subnet was
   added to your network. This always happens especially when neutron is used instead of
   nova-network.
2. When quota is not enough, instance creating will cause exception, but this should not
   fail allocate immediately. Allocate should fail only when alloacted instances are less
   than minCount.